### PR TITLE
fix: use valid rule name for unit-allowed-list

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
         "color-hex-case": "upper",
         "at-rule-name-space-after": "always-single-line",
         "no-duplicate-at-import-rules": true,
-        "unit-allowlist": [
+        "unit-allowed-list": [
             "em",
             "rem",
             "px",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sharegate/stylelint-config-recommended",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "Sharegate recommended stylelint config.",
     "main": "index.js",
     "repository": "https://github.com/gsoft-inc/sg-stylelint.git",


### PR DESCRIPTION
Sooo,

I derped, I think I got caught up in doing something else, but I basically added an invalid rule.

When using version 2.1.0, you get the following exception:

```
src/components/stylesheet.scss
 1:1  ×  Unknown rule unit-allowlist. Did you mean unit-allowed-list?  unit-allowlist
```

Oops, should be fixed with this.
